### PR TITLE
Address stream artifacting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Netmask: 255.255.255.0
 Gateway: 192.168.1.1
 ```
 
+After establishing a connection, verify the RTSP stream using FFmpeg
+
+```bash
+ffplay -fflags nobuffer -flags low_delay -probesize 32 -rtsp_transport tcp -i "rtsp://192.168.1.10:554/user=admin&password=&channel=1&stream=0.sdp?"
+```
+
+The stream can also be recorded using
+
+```bash
+ffmpeg -i "rtsp://192.168.1.10:554/user=admin&password=&channel=1&stream=0.sdp?" -c:v copy -an recording.mp4
+```
+
 ## Using MediaMTX proxy
 
 MediaMTX can be used to connect to the RTSP server embedded into the camera to
@@ -42,19 +54,7 @@ docker compose up
 Once running, the stream can be played using FFmpeg
 
 ```bash
-ffplay rtsp://<your-ip-address>:<mediamtx-port>/barlus
-```
-
-For low latency FFmpeg streaming, run the following
-
-```bash
 ffplay  -fflags nobuffer -flags low_delay -probesize 32 -rtsp_transport udp -i rtsp://<your-ip-address>:<mediamtx-port>/barlus
-```
-
-The stream can also be recorded using
-
-```bash
-ffmpeg -i rtsp://<your-ip-address>:<mediamtx-port>/barlus -c:v copy -an recording.mp4
 ```
 
 ## ROS 2 interface

--- a/README.md
+++ b/README.md
@@ -59,23 +59,22 @@ ffmpeg -i rtsp://<your-ip-address>:<mediamtx-port>/barlus -c:v copy -an recordin
 
 ## ROS 2 interface
 
-`barlus_gstreamer_proxy`, a light wrapper around GStreamer has been implemented
-to convert frames received from the camera into ROS 2 `sensor_msgs/Image`
-messages. After building `barlus_gstreamer_proxy`, the node can be launched
-using
+`barlus_gstreamer_proxy` has been implemented to convert frames received from
+the camera into ROS 2 `sensor_msgs/Image` messages using GStreamer. After
+building `barlus_gstreamer_proxy`, the node can be launched using
 
 ```bash
 ros2 launch barlus_gstreamer_proxy gstreamer_proxy.launch.py
 ```
 
-The frames will be published to the topic `/barlus/image_raw`. The camera
+The raw frames will be published to the topic `/barlus/image_raw`. The camera
 intrinsics are available on the topic `/barlus/camera_info`.
 
 ## Camera calibration
 
 The camera intrinsics can be retrieved using the [camera_calibration](https://docs.ros.org/en/rolling/p/camera_calibration/index.html)
-node. For example, to calibrate the camera using an 8x6 chessboard, run the
-following:
+node. For example, to calibrate the camera using an [8x6 chessboard](https://wiki.ros.org/camera_calibration/Tutorials/MonocularCalibration?action=AttachFile&do=view&target=check-108.pdf),
+run the following:
 
 ```bash
 ros2 run camera_calibration cameracalibrator --size 8x6 --square 0.108 image:=/barlus/image_mono camera:=/barlus --no-service-check

--- a/barlus_gstreamer_proxy/config/camera_info_underwater.yaml
+++ b/barlus_gstreamer_proxy/config/camera_info_underwater.yaml
@@ -1,0 +1,21 @@
+# Camera intrinsics for the Barlus UW-S5-3PBX10 underwater.
+image_width: 3072
+image_height: 2048
+camera_name: barlus
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [2548.648316, 0.000000, 1504.042370, 0.000000, 2268.726513, 1047.536872, 0.000000, 0.000000, 1.000000]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [-0.322976, 0.178339, -0.004748, 0.004154, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [2266.645264, 0.000000, 1514.693183, 0.000000, 0.000000, 2119.430664, 1041.667874, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000]

--- a/barlus_gstreamer_proxy/config/gstreamer_proxy.yaml
+++ b/barlus_gstreamer_proxy/config/gstreamer_proxy.yaml
@@ -1,8 +1,22 @@
 /barlus/gstreamer_proxy:
   ros__parameters:
-    stream_address: rtsp://192.168.1.17:8554/barlus
+
+    # The default RTSP stream address for the Barlus UW-S5-3PBX10 underwater camera.
+    # If using MediaMTX, this should be the address of the MediaMTX server, e.g.,
+    # stream_address: rtsp://192.168.1.17:8554/barlus
+    stream_address: rtsp://192.168.1.10:554/user=admin&password=&channel=1&stream=0.sdp
+
+    # The path to the camera info file. This file contains the camera calibration information.
     camera_info_url: package://barlus_gstreamer_proxy/config/camera_info_underwater.yaml
+
+    # The frame ID of the camera.
     frame_id: camera_link
+
+    # The default width of the camera image.
     image_width: 3072
+
+    # The default height of the camera image.
     image_height: 2048
+
+    # The name of the camera.
     camera_name: barlus

--- a/barlus_gstreamer_proxy/config/gstreamer_proxy.yaml
+++ b/barlus_gstreamer_proxy/config/gstreamer_proxy.yaml
@@ -1,7 +1,7 @@
 /barlus/gstreamer_proxy:
   ros__parameters:
     stream_address: rtsp://192.168.1.17:8554/barlus
-    camera_info_url: package://barlus_gstreamer_proxy/config/camera_info.yaml
+    camera_info_url: package://barlus_gstreamer_proxy/config/camera_info_underwater.yaml
     frame_id: camera_link
     image_width: 3072
     image_height: 2048

--- a/barlus_gstreamer_proxy/src/gstreamer_proxy.cpp
+++ b/barlus_gstreamer_proxy/src/gstreamer_proxy.cpp
@@ -104,7 +104,7 @@ auto GStreamerProxy::configure_stream() -> bool
   RCLCPP_INFO(get_logger(), "Starting GStreamer pipeline with address: %s", params_.stream_address.c_str());  // NOLINT
 
   // The following configurations are intended for low-latency transport
-  const std::string video_source = "rtspsrc location=" + params_.stream_address;
+  const std::string video_source = "rtspsrc location=" + params_.stream_address + " protocols=tcp";
   const std::string video_codec = "! rtph264depay ! h264parse ! avdec_h264";
   const std::string video_decode = "! decodebin ! videoconvert ! video/x-raw,format=(string)BGR";
   const std::string video_sink_conf = "! queue ! appsink emit-signals=true sync=false max-buffers=1 drop=true";

--- a/barlus_gstreamer_proxy/src/gstreamer_proxy_parameters.yaml
+++ b/barlus_gstreamer_proxy/src/gstreamer_proxy_parameters.yaml
@@ -6,7 +6,7 @@ gstreamer_proxy:
 
   stream_address:
     type: string
-    default_value: rtsp://192.168.1.17:8554/barlus
+    default_value: rtsp://192.168.1.10:554/user=admin&password=&channel=1&stream=0.sdp
     description: The RTSP stream address. This can be either the stream from the camera itself or from MediaMTX.
 
   camera_info_url:


### PR DESCRIPTION
## Changes Made

This PR revises the GStreamer launch command to use TCP instead of UDP. This addresses issues in the stream such as delays and artifacts.

## Testing

Testing was done with the camera on my desktop.
